### PR TITLE
Add certificate path to npm files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appium-interceptor",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "appium-interceptor",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.5",
       "license": "ISC",
       "dependencies": {
         "@appium/support": "^4.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-interceptor",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "description": "Appium 2.0 plugin to mock api calls for android apps",
   "main": "./lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
     }
   },
   "files": [
-    "lib"
+    "lib",
+    "certificate"
   ],
   "dependencies": {
     "@appium/support": "^4.1.11",


### PR DESCRIPTION
Fixes #14 

We don't publish certificates to npm registry which is required for signing http requests on go.

<img width="807" alt="Screenshot 2024-01-09 at 10 22 59 AM" src="https://github.com/AppiumTestDistribution/appium-interceptor-plugin/assets/20136913/7ba06bcb-457b-433d-ab09-faae192ffbbe">