### PR TITLE
fix: attach requestBody, add proxy error listener & export types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 lib/
 .idea
 .history
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0-beta.7",
   "description": "Appium 2.0 plugin to mock api calls for android apps",
   "main": "./lib/index.js",
+  "types": "./lib/types/index.d.ts",
   "scripts": {
     "build": "npx tsc",
     "test": "mocha --require ts-node/register -p test/plugin.spec.js --exit --timeout 260000",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 import { AppiumInterceptorPlugin } from './plugin';
 export default AppiumInterceptorPlugin;
 export { AppiumInterceptorPlugin };
+
+export { type MockConfig, type SniffConfig, type RequestInfo } from './types';

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,7 +1,7 @@
 import { BasePlugin } from 'appium/plugin';
 import http from 'http';
 import { Application } from 'express';
-import { CliArg, ISessionCapability, MockConfig, SniffConfig } from './types';
+import { CliArg, ISessionCapability, MockConfig, RequestInfo, SniffConfig } from './types';
 import _ from 'lodash';
 import { configureWifiProxy, isRealDevice } from './utils/adb';
 import { cleanUpProxyServer, sanitizeMockConfig, setupProxyServer } from './utils/proxy';
@@ -139,7 +139,7 @@ export class AppiumInterceptorPlugin extends BasePlugin {
     proxy.enableMock(id);
   }
 
-  async startListening(next: any, driver: any, config: SniffConfig) {
+  async startListening(next: any, driver: any, config: SniffConfig): Promise<string> {
     const proxy = proxyCache.get(driver.sessionId);
     if (!proxy) {
       logger.error('Proxy is not running');
@@ -150,7 +150,7 @@ export class AppiumInterceptorPlugin extends BasePlugin {
     return proxy?.addSniffer(config);
   }
 
-  async stopListening(next: any, driver: any, id: any) {
+  async stopListening(next: any, driver: any, id: any): Promise<RequestInfo[]> {
     const proxy = proxyCache.get(driver.sessionId);
     if (!proxy) {
       logger.error('Proxy is not running');

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -19,6 +19,7 @@ import { Mock } from './mock';
 import { RequestInterceptor } from './interceptor';
 import { ApiSniffer } from './api-sniffer';
 import _ from 'lodash';
+import logger from './logger';
 
 export interface ProxyOptions {
   deviceUDID: string;
@@ -79,6 +80,10 @@ export class Proxy {
     );
     this.httpProxy.onRequest(this.handleMockApiRequest.bind(this));
 
+    this.httpProxy.onError((context, error, errorType) => {
+      logger.error(`${errorType}: ${error}`);
+    });
+
     await new Promise((resolve) => {
       this.httpProxy.listen(proxyOptions, () => {
         this._started = true;
@@ -111,9 +116,9 @@ export class Proxy {
     this.mocks.get(id)?.setEnableStatus(false);
   }
 
-  public addSniffer(sniffConfg: SniffConfig): string {
+  public addSniffer(sniffConfig: SniffConfig): string {
     const id = uuid();
-    const parsedConfig = !sniffConfg ? {} : parseJson(sniffConfg);
+    const parsedConfig = !sniffConfig ? {} : parseJson(sniffConfig);
     this.sniffers.set(id, new ApiSniffer(id, parsedConfig));
     return id;
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,9 @@
       "allowJs": true,                       /* Allow javascript files to be compiled. */
       // "checkJs": true,                       /* Report errors in .js files. */
       // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-      // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-      // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+      "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+      "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+      "declarationDir": "./lib/types",           /* Redirect declarations output structure to the directory. */
       "sourceMap": true,                     /* Generates corresponding '.map' file. */
       // "outFile": "./",                       /* Concatenate and emit output to single file. */
       "outDir": "./lib",                        /* Redirect output structure to the directory. */


### PR DESCRIPTION
## Motivation

While trying to intercept requests in a typescript based solution with webdriverIo and its appium service for E2E tests of an android app, faced some challenges.

Did not have network security settings in the app to allow user installed certificates, thus no requests were intercepted as proxy was erroring. However, this error was never logged in appium logs.

Additionally, the types were not exported and took some effort to discover the correct SnifferConfig object.

Last but not least, after the requests were intercepted there was no requestBody value attached in the RequestInfo object.

## Description of the change

Added 

- value to requestBody
- added onError to log on proxy config
- exported the required types
- fixed a typo on an argument name