### PR TITLE
Updated host in headers

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -53,6 +53,7 @@ export function modifyRequestUrl(ctx: IContext, mockConfig: MockConfig) {
   ctx.proxyToServerRequestOptions.host = updatedUrl.hostname;
   ctx.proxyToServerRequestOptions.path = `${updatedUrl.pathname}${updatedUrl.search}`;
   ctx.proxyToServerRequestOptions.port = updatedUrl.port || ctx.proxyToServerRequestOptions.port;
+  ctx.proxyToServerRequestOptions.headers.host=updatedUrl.hostname;
 }
 
 export function modifyRequestHeaders(ctx: IContext, mockConfig: MockConfig) {

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -53,7 +53,7 @@ export function modifyRequestUrl(ctx: IContext, mockConfig: MockConfig) {
   ctx.proxyToServerRequestOptions.host = updatedUrl.hostname;
   ctx.proxyToServerRequestOptions.path = `${updatedUrl.pathname}${updatedUrl.search}`;
   ctx.proxyToServerRequestOptions.port = updatedUrl.port || ctx.proxyToServerRequestOptions.port;
-  ctx.proxyToServerRequestOptions.headers.host=updatedUrl.hostname;
+  ctx.proxyToServerRequestOptions.headers.host= updatedUrl.hostname;
 }
 
 export function modifyRequestHeaders(ctx: IContext, mockConfig: MockConfig) {


### PR DESCRIPTION
When using the functionality of updateUrl, in the case when we are updating the complete url or the only the base url to send the request to different server, the hostName in headers is not getting updated due to which the request gets failed at the server end. This code is just updating the host in header based on the Updated Url