### PR TITLE
Fix: issues/33 | Java example Update 

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -270,7 +270,7 @@ config.put("responseBody","{\n" +
                         "    }\n" +
                         "  ]\n" +
                         "}");
-((JavascriptExecutor)DriverManager.getDriver()).executeScript("interceptor: addMock",config);
+((JavascriptExecutor)DriverManager.getDriver()).executeScript("interceptor: addMock", new HashMap(){{put("config", config); }});
 driver.findElement(By.xpath("//android.widget.TextView[contains(@text,'List')]")).click();
 ```
 


### PR DESCRIPTION
There was a key config miss in java example , it was causing issue , was throwing error  The following script arguments are not known and will be ignored: url,statusCode.

https://github.com/AppiumTestDistribution/appium-interceptor-plugin/issues/33