### PR TITLE
Error: Cannot write headers after they are sent to the client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appium-interceptor",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.1-beta.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "appium-interceptor",
-      "version": "1.0.0-beta.11",
+      "version": "1.0.1-beta.12",
       "license": "ISC",
       "dependencies": {
         "@appium/support": "^4.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-interceptor",
-  "version": "1.0.0-beta.12",
+  "version": "1.0.1-beta.12",
   "description": "Appium 2.0 plugin to mock api calls for android apps",
   "main": "./lib/index.js",
   "types": "./lib/types/index.d.ts",

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -220,7 +220,12 @@ export class Proxy {
       ctx.proxyToClientResponse.writeHead(mockConfig.statusCode);
       ctx.proxyToClientResponse.end(mockConfig.responseBody);
     } else {
-      modifyResponseBody(ctx, mockConfig);
+      try{
+        modifyResponseBody(ctx, mockConfig);
+      }catch (error) {
+        log.error(`Error modifying response body: ${error}`);
+        next();
+      }
       next();
     }
   }


### PR DESCRIPTION
Added try catch block to handle Error: Cannot write headers after they are sent to the client