### PR TITLE
Add new command to get proxy state

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -398,3 +398,36 @@ Below code shows how to add the mock and get the id
                         new HashMap() {{put("config", config); }});
 
 ```
+
+### interceptor: getProxyState
+
+Returns the current health and configuration state of both the interceptor proxy and the ADB device under test. This is useful for diagnostic purposes to verify if the proxy is running correctly and if the device is properly connected via ADB reverse tunnels. It can be used to monitor proxy state on client side.
+
+#### Example:
+
+```javascript
+  const state = await driver.execute("interceptor: getProxyState");
+  console.log(JSON.parse(state));
+```
+
+#### Returns:
+
+getProxyState will return a JSON string containing details about the proxy server and the ADB device status.
+  
+```json
+{
+  "proxyServerStatus": {
+    "isRegistered": true, // Indicates if the proxy exists in the internal cache
+    "isStarted": true, // Indicates if the proxy server is currently running
+    "deviceUDID": "R5CY127XBWB",
+    "sessionId": "8e902882-ce19-44f6-90ca-975b167f94ca",
+    "certificatePath": "/var/folders/.../8e902882-ce19-44f6-90ca-975b167f94ca",
+    "port": 59046,
+    "ip": "localhost"
+  },
+  "adbDeviceStatus": {
+    "udid": "R5CY127XBWB",
+    "activeAdbReverseTunnels": "UsbFfs tcp:56982 tcp:56982" // Current active reverse tunnels on the device
+  }
+}
+```

--- a/src/utils/adb.ts
+++ b/src/utils/adb.ts
@@ -83,6 +83,30 @@ export async function getGlobalProxyValue(
   }  
 }
 
+/**
+ * Retrieves the list of all active ADB reverse port forwardings for a specific device.
+ * * This method executes 'adb reverse --list' to identify which device ports are 
+ * currently bridged to the host machine. It is essential for diagnosing 
+ * connectivity between the mobile device and local proxy servers.
+ *
+ * @param adb - The ADB instance provided by the Appium driver.
+ * @param udid - The Unique Device Identifier (UDID) of the target Android device.
+ * @returns A Promise resolving to the raw string output of the 'adb reverse --list' command.
+ * @throws {Error} If the command fails to execute or the device is unreachable.
+ */
+export async function getAdbReverseTunnels(
+  adb: ADBInstance,
+  udid: UDID
+): Promise<string> {
+  try {
+    return await adbExecWithDevice(adb, udid, [
+      'reverse',
+      '--list',
+    ]);
+  } catch(error: any) {
+    throw new Error(`Failed to list active reverse tunnels for device ${udid}: ${error.message}`);
+  }
+}
 
 export async function openUrl(adb: ADBInstance, udid: UDID, url: string) {
   await adbExecWithDevice(adb, udid, [


### PR DESCRIPTION
**[ISSUE]**

Sometimes during a test session, the proxy configuration becomes broken and the device under test loses its internet connection. In light of this, we need a way to monitor the proxy state (the current proxy server configuration + the current proxy configuration on the connected device).

**[SOLUTION]** 

Add a new command `getProxyState` that returns a Promise resolving to a JSON string representing the combined state of the proxy and the current proxy configuration on the device.

Example of use : 
<img width="772" height="103" alt="image" src="https://github.com/user-attachments/assets/41050b3a-6e29-4fed-ba02-5ebd106948a1" />

It will print something like this every 30s: 
<img width="478" height="422" alt="image" src="https://github.com/user-attachments/assets/881ed5bd-84f5-4026-abb2-adb0ef292d7e" />
