### PR TITLE
FEAT : Add appium:interceptionPort session capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ To control the plugin behavior, you can use the following capabilities:
 | Capability                       | Type      | Default | Description                                                                                                              |
 | :------------------------------- | :-------- | :------ | :----------------------------------------------------------------------------------------------------------------------- |
 | `appium:startProxyAutomatically` | `boolean` | `false` | When `true`, the plugin initializes the proxy server and configures the device WiFi immediately during session creation. |
+| `appium:interceptionPort`        | `number`  | *None*  | Optional. Specifies a fixed port number to use for the interception proxy server instead of a randomly selected free port. |
 
 ---
 
@@ -75,7 +76,8 @@ Set `appium:startProxyAutomatically` to `true` in your capabilities. The plugin 
 const caps = {
   "platformName": "Android",
   "appium:automationName": "UiAutomator2",
-  "appium:startProxyAutomatically": true
+  "appium:startProxyAutomatically": true,
+  "appium:interceptionPort": 9000 // Optional: specifies a fixed port instead of selecting a free port randomly
 };
 ```
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -136,7 +136,8 @@ export class AppiumInterceptorPlugin extends BasePlugin {
       log.debug(
         `[${sessionId}] Capability 'startProxyAutomatically' is enabled. Initializing proxy setup...`,
       );
-      await this.setupProxy(adb, sessionId, deviceUDID);
+      const interceptionPort = mergedCaps['appium:interceptionPort'];
+      await this.setupProxy(adb, sessionId, deviceUDID, interceptionPort);
     } else {
       log.debug(
         `[${sessionId}] Capability 'startProxyAutomatically' is disabled. Use command 'startProxy' to start proxy.`,
@@ -237,7 +238,9 @@ export class AppiumInterceptorPlugin extends BasePlugin {
   }
 
   async startProxy(_next: any, driver: any) {
-    await this.setupProxy(driver.adb, driver.sessionId, driver.adb?.curDeviceId);
+    const caps = { ...driver.caps, ...driver.opts };
+    const interceptionPort = caps['appium:interceptionPort'];
+    await this.setupProxy(driver.adb, driver.sessionId, driver.adb?.curDeviceId, interceptionPort);
   }
 
   async stopProxy(_next: any, driver: any) {
@@ -255,8 +258,8 @@ export class AppiumInterceptorPlugin extends BasePlugin {
     return proxy;
   }
 
-  private async setupProxy(adb: ADBInstance, sessionId: string, deviceUDID: UDID) {
-    log.debug(`setupProxy(sessionId=${sessionId}, deviceUDID:${deviceUDID})`);
+  private async setupProxy(adb: ADBInstance, sessionId: string, deviceUDID: UDID, interceptionPort?: number) {
+    log.debug(`setupProxy(sessionId=${sessionId}, deviceUDID:${deviceUDID}, interceptionPort:${interceptionPort})`);
 
     if (proxyCache.get(sessionId)) {
       log.warn(`[${sessionId}] A proxy is already active for this session. Skipping setup.`);
@@ -290,6 +293,7 @@ export class AppiumInterceptorPlugin extends BasePlugin {
         currentGlobalProxy,
         whitelistedDomains,
         blacklistedDomains,
+        interceptionPort,
       );
 
       await configureWifiProxy(adb, deviceUDID, realDevice, proxy.options);

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -115,10 +115,17 @@ export async function setupProxyServer(
   certDirectory: string,
   currentWifiProxyConfig?: ProxyOptions,
   whitelistedDomains?: string[],
-  blacklistedDomains?: string[]
+  blacklistedDomains?: string[],
+  interceptionPort?: number
 ) {
   const certificatePath = prepareCertificate(sessionId, certDirectory);
-  const port = await getPort();
+  if (interceptionPort) {
+    log.info(`Using custom interception port from capabilities: ${interceptionPort}`);
+  } else {
+    log.info(`No custom interception port specified in capabilities. Selecting a free port randomly...`);
+  }
+  const port = interceptionPort ? Number(interceptionPort) : await getPort();
+  log.info(`Selected port: ${port}`);
   const _ip = isRealDevice ? 'localhost' : ip.address('public', 'ipv4');
   const proxy = new Proxy({ deviceUDID, sessionId, certificatePath, port, ip: _ip, previousConfig: currentWifiProxyConfig, whitelistedDomains, blacklistedDomains});
   await proxy.start();


### PR DESCRIPTION
## Context

Currently, the Appium Interceptor Plugin dynamically selects a random free port for running the interception proxy. To allow developers to run tests on predictable ports or isolate concurrent sessions, we need a way to specify a custom interception port.

## Implementation
- Added `appium:interceptionPort` session capability support.
- Updated `setupProxy` and `setupProxyServer` to parse and use this port if provided, defaulting to dynamic port selection if omitted.
- Added info-level logging to notify whether a custom port is utilized or dynamically selected.
- Updated `README.md` to document the new capability.

## Requirements 
*  [x] Self code-review
*  [x] Documentation updated
*  [x] Manual tests performed (self test)
