### PR TITLE
feat: add interceptor:removeAllMocks command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -134,6 +134,32 @@ Given a mockId return during addMock command, will remove the mock configuration
  // authorizationMock will not be active after this point and the test will proceed with normal flow
 ```
 
+### interceptor: removeAllMocks
+Removes all registered mock configurations from the proxy server at once.
+
+#### Example:
+
+```javascript
+ await driver.execute("interceptor: addMock", {
+    config: {
+        url: "**/api/users/**",
+        statusCode: 400
+    }
+ });
+
+ await driver.execute("interceptor: addMock", {
+    config: {
+        url: "**/api/login/**",
+        statusCode: 401
+    }
+ });
+
+ // Perform actions under mock state...
+
+ // Remove all mocks at once to return to normal flow
+ await driver.execute("interceptor: removeAllMocks");
+```
+
 ### interceptor: startListening
 
 Start listening for all network traffic (API calls) made by the device during a session

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -37,6 +37,9 @@ export class AppiumInterceptorPlugin extends BasePlugin {
       command: 'removeMock',
       params: { required: ['id'] },
     },
+    'interceptor: removeAllMocks': {
+      command: 'removeAllMocks',
+    },
     'interceptor: disableMock': {
       command: 'disableMock',
       params: { required: ['id'] },
@@ -176,6 +179,12 @@ export class AppiumInterceptorPlugin extends BasePlugin {
     const proxy = this.getSessionProxy(driver.sessionId);
     log.debug(`[${driver.sessionId}] Removing mock rule with ID: ${id}`);
     proxy.removeMock(id);
+  }
+
+  async removeAllMocks(_next: any, driver: any) {
+    const proxy = this.getSessionProxy(driver.sessionId);
+    log.debug(`[${driver.sessionId}] Removing all mock rules`);
+    proxy.removeAllMocks();
   }
 
   async disableMock(_next: any, driver: any, id: string) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -201,6 +201,14 @@ export class Proxy {
     this.mocks.delete(id);
   }
 
+  public removeAllMocks(): void {
+    this.mocks.clear();
+  }
+
+  public getMockCount(): number {
+    return this.mocks.size;
+  }
+
   public enableMock(id: string): void {
     this.mocks.get(id)?.setEnableStatus(true);
   }

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -127,6 +127,43 @@ describe('Plugin Test', () => {
     expect(page.includes('Error')).to.be.true;
   });
 
+  it('Should be able to remove all mocks at once', async () => {
+    const mockId = await driver.execute('interceptor: addMock', {
+      config: {
+        url: '/api/users?.*',
+        responseBody: JSON.stringify({
+          page: 1,
+          per_page: 1,
+          total: 1,
+          total_pages: 1,
+          data: [
+            {
+              id: 1,
+              email: 'allmocksremoved.test@reqres.in',
+              first_name: 'Removed',
+              last_name: 'Mocks',
+            },
+          ],
+        }),
+      },
+    });
+    expect(mockId).to.not.be.null;
+
+    // Verify mock is active
+    const el1 = await driver.$('xpath://android.widget.TextView[@text="Get User List"]');
+    await el1.click();
+    let page = await driver.getPageSource();
+    expect(page.includes('allmocksremoved.test@reqres.in')).to.be.true;
+
+    // Now remove all mocks
+    await driver.execute('interceptor: removeAllMocks');
+
+    // Click again and verify mock is no longer applied
+    await el1.click();
+    page = await driver.getPageSource();
+    expect(page.includes('allmocksremoved.test@reqres.in')).to.be.false;
+  });
+
   afterEach(async () => {
     await driver.deleteSession();
   });

--- a/test/unit.spec.ts
+++ b/test/unit.spec.ts
@@ -1,0 +1,55 @@
+import { expect } from 'chai';
+import { Proxy } from '../src/proxy';
+import { AppiumInterceptorPlugin } from '../src/plugin';
+import proxyCache from '../src/proxy-cache';
+
+describe('Unit Tests - removeAllMocks', () => {
+  it('should successfully add and remove all mocks from Proxy', () => {
+    const proxy = new Proxy({
+      deviceUDID: 'test-udid',
+      sessionId: 'test-session',
+      certificatePath: 'test-cert-path',
+      port: 12345,
+      ip: '127.0.0.1',
+    });
+
+    expect(proxy.getMockCount()).to.equal(0);
+
+    const mockId1 = proxy.addMock({ url: '/api/test1' });
+    const mockId2 = proxy.addMock({ url: '/api/test2' });
+
+    expect(proxy.getMockCount()).to.equal(2);
+
+    proxy.removeAllMocks();
+
+    expect(proxy.getMockCount()).to.equal(0);
+  });
+
+  it('should successfully call removeAllMocks from AppiumInterceptorPlugin command', async () => {
+    const plugin = new AppiumInterceptorPlugin('interceptor', {});
+    const proxy = new Proxy({
+      deviceUDID: 'test-udid',
+      sessionId: 'test-session',
+      certificatePath: 'test-cert-path',
+      port: 12345,
+      ip: '127.0.0.1',
+    });
+
+    proxyCache.add('test-session', proxy);
+
+    const driver = {
+      sessionId: 'test-session',
+    };
+
+    await plugin.addMock(null, driver, { url: '/api/test1' });
+    await plugin.addMock(null, driver, { url: '/api/test2' });
+
+    expect(proxy.getMockCount()).to.equal(2);
+
+    await plugin.removeAllMocks(null, driver);
+
+    expect(proxy.getMockCount()).to.equal(0);
+
+    proxyCache.remove('test-session');
+  });
+});


### PR DESCRIPTION
## Context

Currently, the Appium Interceptor Plugin only provided the command `interceptor: removeMock` which requires a specific `mockId` to remove a single mock rule. In complex automated test suites, this can make clean teardown hooks tedious, flaky, and verbose. This PR adds a new command `interceptor: removeAllMocks` to clear the complete mock registry in a single call.

## Implementation

1. **Proxy Layer (`src/proxy.ts`):** Added a new public method `removeAllMocks(): void` which cleanly clears the entire internal `this.mocks` `Map`, along with `getMockCount(): number` to securely query the size of active mocks during tests.
2. **Appium Plugin Layer (`src/plugin.ts`):** Registered `'interceptor: removeAllMocks'` in `executeMethodMap` and implemented the driver handler method to invoke the proxy's `removeAllMocks()`.
3. **Tests Covered:**
   - **Unit Tests:** Created a new file `test/unit.spec.ts` containing quick in-memory tests verifying `removeAllMocks` at both the Proxy and Plugin levels.
   - **E2E Integration Test:** Added a test case in `test/plugin.spec.js` asserting that mock registration correctly alters request responses and that invoking `interceptor: removeAllMocks` completely clears all active mock rules.
4. **Documentation:** Updated `docs/commands.md` to document the new command's interface and provided JavaScript/WebdriverIO code usage examples.

## Requirements

- [x] Self code-review
- [x] Unit / Integration
- [x] Documentation updated
- [x] Manual tests performed (self test)

## Documentations

- `docs/commands.md` has been updated with information on the new command.

## Manual tests

- Verified compilation using `npm run build`.
- Executed the newly added unit tests successfully (`npx mocha --require ts-node/register test/unit.spec.ts --exit`).
